### PR TITLE
Enable this package for all python-based grammars

### DIFF
--- a/lib/python-indent.coffee
+++ b/lib/python-indent.coffee
@@ -38,7 +38,7 @@ module.exports = PythonIndent =
   properlyIndent: ->
     # Make sure this is a Python file
     editor = atom.workspace.getActiveTextEditor()
-    return unless editor.getGrammar().name in ['Python', 'MagicPython']
+    return unless editor.getGrammar().scopeName.substring(0, 13) == 'source.python'
 
     # Get base variables
     row = editor.getCursorBufferPosition().row


### PR DESCRIPTION
To make this package work with atom-django, which has a grammar scope of "source.python.django", we detect editor scope using `scopeName` instead of `Name`.
