### PR TITLE
Allow for whitespace after comma

### DIFF
--- a/lib/python-indent.coffee
+++ b/lib/python-indent.coffee
@@ -8,7 +8,7 @@ module.exports = PythonIndent =
       description: 'Regular Expression for _aligned with opening delimiter_ continuation indent type, and used for determining when this type of indent should be _started_.'
     openingDelimiterUnindentRegex:
       type: 'string'
-      default: '^\\s+\\S*(\\)|\\]):?$'
+      default: '^\\s+\\S*(\\)|\\])\\s*:?\\s*$'
       description: 'Regular Expression for _aligned with opening delimiter_ continuation indent type, and used for determining when this type of indent should be _ended_.'
     hangingIndentRegex:
       type: 'string'

--- a/lib/python-indent.coffee
+++ b/lib/python-indent.coffee
@@ -4,7 +4,7 @@ module.exports = PythonIndent =
   config:
     openingDelimiterIndentRegex:
       type: 'string'
-      default: '^.*(\\(|\\[).*,$'
+      default: '^.*(\\(|\\[).*,\\s*$'
       description: 'Regular Expression for _aligned with opening delimiter_ continuation indent type, and used for determining when this type of indent should be _started_.'
     openingDelimiterUnindentRegex:
       type: 'string'

--- a/lib/python-indent.coffee
+++ b/lib/python-indent.coffee
@@ -12,7 +12,7 @@ module.exports = PythonIndent =
       description: 'Regular Expression for _aligned with opening delimiter_ continuation indent type, and used for determining when this type of indent should be _ended_.'
     hangingIndentRegex:
       type: 'string'
-      default: '^.*(\\(|\\[)$'
+      default: '^.*(\\(|\\[)\\s*$'
       description: 'Regular Expression for _hanging indent_ used for determining when this type of indent should be _started_.'
     hangingIndentTabs:
       type: 'number'


### PR DESCRIPTION
If there is trailing whitespace after the last comma before the user hits
RETURN, the next line is now correctly indented.

This will close #6.
