### PR TITLE
Don't throw errors when source code is malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.2 - Errors on Malformed Code
+- Don't throw error when source code is malformed. This fixed #17.
+
 ## 0.4.1 - Hanging Indent Continuation Fix
 - Properly indent continuing lines in a hanging indent after closing a nested bracket pair. This fixed #15.
 - Improve test coverage.

--- a/lib/python-indent.coffee
+++ b/lib/python-indent.coffee
@@ -35,7 +35,7 @@ class PythonIndent
         @indentHanging(row, @editor.buffer.lineForRow(row - 1))
         return
 
-    return unless openBracketStack.length or lastClosedRow.length
+    return unless openBracketStack.length or (lastClosedRow.length and openBracketStack)
 
     if not openBracketStack.length
         # can assume lastClosedRow is not empty
@@ -218,7 +218,7 @@ class PythonIndent
 
                     if c == ':'
                         lastFunctionRow = row
-                    else if c in '})]'
+                    else if c in '})]' and openBracketStack.length
                         # Note that the .pop() will take the element off of the openBracketStack
                         # as it adds it to the array for lastClosedRow.
                         lastClosedRow = [openBracketStack.pop()[0], row]

--- a/spec/python-indent-spec.coffee
+++ b/spec/python-indent-spec.coffee
@@ -241,6 +241,30 @@ describe 'python-indent', ->
         pythonIndent.properlyIndent()
         expect(buffer.lineForRow 3).toBe ' '.repeat 4
 
+      '''
+      for i in range(10):
+          for j in range(20):
+              def f(x=[0,1,2,
+                       3,4,5]):
+                  return x * i * j
+      '''
+      it 'indents properly when blocks and lists are deeply nested', ->
+        editor.insertText 'for i in range(10):\n'
+        pythonIndent.properlyIndent()
+        expect(buffer.lineForRow 1).toBe ' '.repeat 4
+
+        editor.insertText 'for j in range(20):\n'
+        editor.autoIndentSelectedRows 2
+        expect(buffer.lineForRow 2).toBe ' '.repeat 8
+
+        editor.insertText 'def f(x=[0,1,2,\n'
+        pythonIndent.properlyIndent()
+        expect(buffer.lineForRow 3).toBe ' '.repeat 17
+
+        editor.insertText '3,4,5]):\n'
+        pythonIndent.properlyIndent()
+        expect(buffer.lineForRow 4).toBe ' '.repeat 12
+
     describe 'when unindenting after newline :: aligned with opening delimiter', ->
 
       '''
@@ -442,3 +466,15 @@ describe 'python-indent', ->
         editor.insertText 'arg3, arg4),\n'
         pythonIndent.properlyIndent()
         expect(buffer.lineForRow 3).toBe ' '.repeat 4
+
+  describe 'when source is malformed', ->
+
+    '''
+    class DoesBadlyFormedCodeBreak )
+    '''
+    it 'does not throw error or indent when code is malformed', ->
+      editor.insertText 'class DoesBadlyFormedCodeBreak )\n'
+      expect ->
+        pythonIndent.properlyIndent()
+      .not.toThrow()
+      expect(buffer.lineForRow 1).toBe ''

--- a/spec/test_file.py
+++ b/spec/test_file.py
@@ -97,3 +97,5 @@ for i in range(10):
         def f(x=[0,1,2,
                  3,4,5]):
             return x * i * j
+
+class DoesBadlyFormedCodeBreak )


### PR DESCRIPTION
cc: @kbrose

An issue was reported where a new line was entered after a closing
bracket with _no_ matching opening bracket. This causes an error
when popping a non-existing opening bracket off the array of
bracket match locations. This commit simply makes sure there are
elements in the open bracket stack before trying to pop an element
off of it, and provides test cases to illustrate the thrown error
(and prevent regression).
