### PR TITLE
Fix activation syntax problem, fix edge case for quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.0.1] - 2017-03-10
 ### Changed
-- Name of `properlyIndent` function to just be `indent`.
+- Update name of `properlyIndent` function to just be `indent`.
 - Conform to [Keep a Changelog](http://keepachangelog.com/)
 - Update formatting and fixed indentation error in the README.
 - Update example GIF.
 - Fix test documentation formatting.
+- Update license copyright.
+- Update eslint, eslint-config-airbnb-base, and eslint-plugin-import to their latest versions.
 
-## [1.0.0](https://github.com/DSpeckhals/python-indent/compare/v0.4.3...v1.0.0) - 2016-09-15
+### Fixed
+- Fix broken package activation discovered by an Atom beta channel (1.16.0-beta0) user. This appears
+to have been caused by an Atom core Babel upgrade and this package using the incorrect type of function
+declaration.
+- Fix incorrect indent in the rare case when an unterminated comment character occurs within a
+triple-quoted string. Also add a spec that will catch any future regressions for this case. This
+fixed #33.
+
+## [1.0.0] - 2016-09-15
 ### Changed
 - Update to ES6; functionality should be the same as 0.4.3
 
@@ -103,7 +113,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/DSpeckhals/python-indent/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/DSpeckhals/python-indent/compare/v0.4.3...v1.0.0
 [0.4.3]: https://github.com/DSpeckhals/python-indent/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/DSpeckhals/python-indent/compare/v0.4.1...v0.4.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Dustin Speckhals
+Copyright (c) 2016-2017 Dustin Speckhals
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 "use babel";
 
-import { CompositeDisposable } from "atom"; // eslint-disable-line import/no-unresolved
+import { CompositeDisposable } from "atom"; // eslint-disable-line
 import PythonIndent from "./python-indent";
 
 export default {
@@ -15,7 +15,8 @@ export default {
             ],
         },
     },
-    activate: () => {
+
+    activate() {
         this.pythonIndent = new PythonIndent();
         this.subscriptions = new CompositeDisposable();
         this.subscriptions.add(atom.commands.add("atom-text-editor",

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -1,4 +1,5 @@
 "use babel";
+
 export default class PythonIndent {
 
     indent() {
@@ -19,7 +20,7 @@ export default class PythonIndent {
         // so remove the last element of lines, which will be the empty line
         lines = lines.splice(0, lines.length - 1);
 
-        const parseOutput = this.parseLines(lines);
+        const parseOutput = PythonIndent.parseLines(lines);
         // openBracketStack: A stack of [row, col] pairs describing where open brackets are
         // lastClosedRow: Either empty, or an array [rowOpen, rowClose] describing the rows
         //  here the last bracket to be closed was opened and closed.
@@ -136,7 +137,7 @@ export default class PythonIndent {
         this.editor.getBuffer().setTextInRange([startRange, stopRange], indent);
     }
 
-    parseLines(lines) {
+    static parseLines(lines) {
         // openBracketStack is an array of [row, col] indicating the location
         // of the opening bracket (square, curly, or parentheses)
         const openBracketStack = [];
@@ -145,22 +146,11 @@ export default class PythonIndent {
         let lastClosedRow = [];
         // If we are in a string, this tells us what character introduced the string
         // i.e., did this string start with ' or with "?
-        let stringDelimiter = [];
+        let stringDelimiter = null;
         // This is the row of the last function definition
         let lastColonRow = NaN;
-
         // true if we are in a triple quoted string
         let inTripleQuotedString = false;
-
-        // If we have seen two of the same string delimiters in a row,
-        // then we have to check the next character to see if it matches
-        // in order to correctly parse triple quoted strings.
-        let checkNextCharForString = false;
-
-        // keep track of the number of consecutive string delimiter's we've seen
-        // used to tell if we are in a triple quoted string
-        let numConsecutiveStringDelimiters = 0;
-
         // true if we should have a hanging indent, false otherwise
         let shouldHang = false;
 
@@ -168,17 +158,25 @@ export default class PythonIndent {
         // statements like "[0, (1, 2])" might break the parsing
 
         // loop over each line
-        for (const row of Array(lines.length).fill().map((_, i) => i)) {
+        const linesLength = lines.length;
+        for (let row = 0; row < linesLength; row += 1) {
             const line = lines[row];
 
+            // Keep track of the number of consecutive string delimiter's we've seen
+            // in this line; this is used to tell if we are in a triple quoted string
+            let numConsecutiveStringDelimiters = 0;
+            // If we have seen two of the same string delimiters in a row,
+            // then we have to check the next character to see if it matches
+            // in order to correctly parse triple quoted strings.
+            let checkNextCharForString = false;
             // boolean, whether or not the current character is being escaped
             // applicable when we are currently in a string
             let isEscaped = false;
 
             // This is the last defined def/for/if/elif/else/try/except row
             const lastlastColonRow = lastColonRow;
-
-            for (const col of Array(line.length).fill().map((_, i) => i)) {
+            const lineLength = line.length;
+            for (let col = 0; col < lineLength; col += 1) {
                 const c = line[col];
 
                 if (c === stringDelimiter && !isEscaped) {
@@ -194,96 +192,91 @@ export default class PythonIndent {
 
                 // If stringDelimiter is set, then we are in a string
                 // Note that this works correctly even for triple quoted strings
-                if (stringDelimiter.length) {
+                if (stringDelimiter) {
                     if (isEscaped) {
                         // If current character is escaped, then we do not care what it was,
                         // but since it is impossible for the next character to be escaped as well,
                         // go ahead and set that to false
                         isEscaped = false;
-                    } else {
-                        if (c === stringDelimiter) {
-                            // We are seeing the same quote that started the string, i.e. ' or "
-                            if (inTripleQuotedString) {
-                                if (numConsecutiveStringDelimiters === 3) {
-                                    // Breaking out of the triple quoted string...
-                                    numConsecutiveStringDelimiters = 0;
-                                    stringDelimiter = [];
-                                    inTripleQuotedString = false;
-                                }
-                            } else if (numConsecutiveStringDelimiters === 3) {
-                                // reset the count, correctly handles cases like ''''''
+                    } else if (c === stringDelimiter) {
+                        // We are seeing the same quote that started the string, i.e. ' or "
+                        if (inTripleQuotedString) {
+                            if (numConsecutiveStringDelimiters === 3) {
+                                // Breaking out of the triple quoted string...
                                 numConsecutiveStringDelimiters = 0;
-                                inTripleQuotedString = true;
-                            } else if (numConsecutiveStringDelimiters === 2) {
-                                // We are not currently in a triple quoted string, and we've
-                                // seen two of the same string delimiter in a row. This could
-                                // either be an empty string, i.e. '' or "", or it could be
-                                // the start of a triple quoted string. We will check the next
-                                // character, and if it matches then we know we're in a triple
-                                // quoted string, and if it does not match we know we're not
-                                // in a string any more (i.e. it was the empty string).
-                                checkNextCharForString = true;
-                            } else if (numConsecutiveStringDelimiters === 1) {
-                                // We are not in a string that is not triple quoted, and we've
-                                // just seen an un-escaped instance of that string delimiter.
-                                // In other words, we've left the string.
-                                // It is also worth noting that it is impossible for
-                                // numConsecutiveStringDelimiters to be 0 at this point, so
-                                // this set of if/else if statements covers all cases.
-                                stringDelimiter = [];
+                                stringDelimiter = null;
+                                inTripleQuotedString = false;
                             }
-                        } else if (c === "\\") {
-                            // We are seeing an unescaped backslash, the next character is escaped.
-                            // Note that this is not exactly true in raw strings, HOWEVER, in raw
-                            // strings you can still escape the quote mark by using a backslash.
-                            // Since that's all we really care about as far as escaped characters
-                            // go, we can assume we are now escaping the next character.
-                            isEscaped = true;
+                        } else if (numConsecutiveStringDelimiters === 3) {
+                            // reset the count, correctly handles cases like ''''''
+                            numConsecutiveStringDelimiters = 0;
+                            inTripleQuotedString = true;
+                        } else if (numConsecutiveStringDelimiters === 2) {
+                            // We are not currently in a triple quoted string, and we've
+                            // seen two of the same string delimiter in a row. This could
+                            // either be an empty string, i.e. '' or "", or it could be
+                            // the start of a triple quoted string. We will check the next
+                            // character, and if it matches then we know we're in a triple
+                            // quoted string, and if it does not match we know we're not
+                            // in a string any more (i.e. it was the empty string).
+                            checkNextCharForString = true;
+                        } else if (numConsecutiveStringDelimiters === 1) {
+                            // We are not in a string that is not triple quoted, and we've
+                            // just seen an un-escaped instance of that string delimiter.
+                            // In other words, we've left the string.
+                            // It is also worth noting that it is impossible for
+                            // numConsecutiveStringDelimiters to be 0 at this point, so
+                            // this set of if/else if statements covers all cases.
+                            stringDelimiter = null;
                         }
+                    } else if (c === "\\") {
+                        // We are seeing an unescaped backslash, the next character is escaped.
+                        // Note that this is not exactly true in raw strings, HOWEVER, in raw
+                        // strings you can still escape the quote mark by using a backslash.
+                        // Since that's all we really care about as far as escaped characters
+                        // go, we can assume we are now escaping the next character.
+                        isEscaped = true;
                     }
+                } else if ("[({".includes(c)) {
+                    openBracketStack.push([row, col]);
+                    // If the only characters after this opening bracket are whitespace,
+                    // then we should do a hanging indent. If there are other non-whitespace
+                    // characters after this, then they will set the shouldHang boolean to false
+                    shouldHang = true;
+                } else if (" \t\r\n".includes(c)) { // just in case there's a new line
+                    // If it's whitespace, we don't care at all
+                    // this check is necessary so we don't set shouldHang to false even if
+                    // someone e.g. just entered a space between the opening bracket and the
+                    // newline.
+                } else if (c === "#") {
+                    // This check goes as well to make sure we don't set shouldHang
+                    // to false in similar circumstances as described in the whitespace section.
+                    break;
                 } else {
-                    if ("[({".includes(c)) {
-                        openBracketStack.push([row, col]);
-                        // If the only characters after this opening bracket are whitespace,
-                        // then we should do a hanging indent. If there are other non-whitespace
-                        // characters after this, then they will set the shouldHang boolean to false
-                        shouldHang = true;
-                    } else if (" \t\r\n".includes(c)) { // just in case there's a new line
-                        // If it's whitespace, we don't care at all
-                        // this check is necessary so we don't set shouldHang to false even if
-                        // someone e.g. just entered a space between the opening bracket and the
-                        // newline.
-                        continue;
-                    } else if (c === "#") {
-                        // This check goes as well to make sure we don't set shouldHang
-                        // to false in similar circumstances as described in the whitespace section.
-                        break;
-                    } else {
-                        // We've already skipped if the character was white-space, an opening
-                        // bracket, or a new line, so that means the current character is not
-                        // whitespace and not an opening bracket, so shouldHang needs to get set to
-                        // false.
-                        shouldHang = false;
+                    // We've already skipped if the character was white-space, an opening
+                    // bracket, or a new line, so that means the current character is not
+                    // whitespace and not an opening bracket, so shouldHang needs to get set to
+                    // false.
+                    shouldHang = false;
 
-                        // Similar to above, we've already skipped all irrelevant characters,
-                        // so if we saw a colon earlier in this line, then we would have
-                        // incorrectly thought it was the end of a def/for/if/elif/else/try/except
-                        // block when it was actually a dictionary being defined, reset the
-                        // lastColonRow variable to whatever it was when we started parsing this
-                        // line.
-                        lastColonRow = lastlastColonRow;
+                    // Similar to above, we've already skipped all irrelevant characters,
+                    // so if we saw a colon earlier in this line, then we would have
+                    // incorrectly thought it was the end of a def/for/if/elif/else/try/except
+                    // block when it was actually a dictionary being defined, reset the
+                    // lastColonRow variable to whatever it was when we started parsing this
+                    // line.
+                    lastColonRow = lastlastColonRow;
 
-                        if (c === ":") {
-                            lastColonRow = row;
-                        } else if ("})]".includes(c) && openBracketStack.length) {
-                            // The .pop() will take the element off of the openBracketStack as it
-                            // adds it to the array for lastClosedRow.
-                            lastClosedRow = [openBracketStack.pop()[0], row];
-                        } else if ("'\"".includes(c)) {
-                            // Starting a string, keep track of what quote was used to start it.
-                            stringDelimiter = c;
-                            numConsecutiveStringDelimiters += 1;
-                        }
+                    if (c === ":") {
+                        lastColonRow = row;
+                    } else if ("})]".includes(c) && openBracketStack.length) {
+                        // The .pop() will take the element off of the openBracketStack as it
+                        // adds it to the array for lastClosedRow.
+                        lastClosedRow = [openBracketStack.pop()[0], row];
+                    } else if ("'\"".includes(c)) {
+                        // Starting a string, keep track of what quote was used to start it.
+                        stringDelimiter = c;
+                        numConsecutiveStringDelimiters += 1;
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.13.1",
-    "eslint-config-airbnb-base": "^3.0.1",
-    "eslint-plugin-import": "^1.10.0"
+    "eslint": "^3.17.1",
+    "eslint-config-airbnb-base": "^11.1.1",
+    "eslint-plugin-import": "^2.2.0"
   }
 }

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -1,5 +1,7 @@
 "use babel";
+
 import PythonIndent from "../lib/python-indent";
+
 describe("python-indent", () => {
     const FILE_NAME = "fixture.py";
     let buffer = null;
@@ -13,7 +15,7 @@ describe("python-indent", () => {
                 editor.setSoftTabs(true);
                 editor.setTabLength(4);
                 buffer = editor.buffer;
-            })
+            }),
         );
 
         waitsForPromise(() => {
@@ -32,7 +34,7 @@ describe("python-indent", () => {
         waitsForPromise(() =>
             atom.packages.activatePackage("python-indent").then(() => {
                 pythonIndent = new PythonIndent();
-            })
+            }),
         );
     });
 
@@ -40,7 +42,7 @@ describe("python-indent", () => {
         it("loads python file and package", () => {
             expect(editor.getPath()).toContain(FILE_NAME);
             expect(atom.packages.isPackageActive("python-indent")).toBe(true);
-        })
+        }),
     );
 
     // Aligned with opening delimiter
@@ -305,10 +307,26 @@ describe("python-indent", () => {
             var_name = [0, 1, 2,
             */
             it("handles even number of string delimiters inside triple quoted string", () => {
-                editor.insertText("\"\"\" a quote with a two string delimiters: \"\" \"\"\"\n");
+                editor.insertText("\"\"\" a quote with two string delimiters: \"\" \"\"\"\n");
                 editor.insertText("var_name = [0, 1, 2,\n");
                 pythonIndent.indent();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(12));
+            });
+
+            /*
+            """
+            Here is just one quote: "
+            """
+            x = [0, 1, 2,
+                 4, 5, 6]
+            */
+            it("handles a single delimiter inside a triple quoted string of the same delimiter", () => {
+                editor.insertText("\"\"\"\n");
+                editor.insertText("Here is just one quote: \"\n");
+                editor.insertText("\"\"\"\n");
+                editor.insertText("x = [0, 1, 2,\n");
+                pythonIndent.indent();
+                expect(buffer.lineForRow(4)).toBe(" ".repeat(5));
             });
 
             /*
@@ -574,6 +592,6 @@ describe("python-indent", () => {
             expect(() => pythonIndent.indent())
             .not.toThrow();
             expect(buffer.lineForRow(1)).toBe("");
-        })
+        }),
     );
 });

--- a/spec/test_file.py
+++ b/spec/test_file.py
@@ -1,6 +1,5 @@
 # This file represents all known cases of special-case indentations
 
-
 x = [0, 1, 2,
      3, 4, 5]
 
@@ -75,7 +74,6 @@ x = [  #
 
 # def f():
 
-
 def f(arg1, arg2, arg3,
       arg4, arg5, arg6=')\)',
       arg7=0):
@@ -99,12 +97,10 @@ for i in range(10):
                  3,4,5]):
             return x * i * j
 
-
 '''
 Here is just one quote: '
 '''
 x = [0, 1, 2,
      4, 5, 6]
-
 
 class DoesBadlyFormedCodeBreak )


### PR DESCRIPTION
- Fix broken package activation discovered by an Atom beta channel
(1.16.0-beta0) user. This appears to have been caused by an Atom
core Babel upgrade and this package using the incorrect type of
function declaration.

- Fix incorrect indent in the rare case when an un-terminated
comment character occurs within a triple-quoted string. Also add
a spec that will catch any future regressions for this case. This fixes #33.