### PR TITLE
Fix issue when empty string is in the markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.2] - 2017-03-15
+### Fixed
+- Fix scenario when an empty string is virtually anywhere in the markup and causes
+any further indentation to be wrong. This fixed #35.
+
 ## [1.0.1] - 2017-03-10
 ### Changed
 - Update name of `properlyIndent` function to just be `indent`.
@@ -113,7 +118,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/DSpeckhals/python-indent/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/DSpeckhals/python-indent/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/DSpeckhals/python-indent/compare/v0.4.3...v1.0.0
 [0.4.3]: https://github.com/DSpeckhals/python-indent/compare/v0.4.2...v0.4.3

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -151,6 +151,10 @@ export default class PythonIndent {
         let lastColonRow = NaN;
         // true if we are in a triple quoted string
         let inTripleQuotedString = false;
+        // If we have seen two of the same string delimiters in a row,
+        // then we have to check the next character to see if it matches
+        // in order to correctly parse triple quoted strings.
+        let checkNextCharForString = false;
         // true if we should have a hanging indent, false otherwise
         let shouldHang = false;
 
@@ -165,10 +169,6 @@ export default class PythonIndent {
             // Keep track of the number of consecutive string delimiter's we've seen
             // in this line; this is used to tell if we are in a triple quoted string
             let numConsecutiveStringDelimiters = 0;
-            // If we have seen two of the same string delimiters in a row,
-            // then we have to check the next character to see if it matches
-            // in order to correctly parse triple quoted strings.
-            let checkNextCharForString = false;
             // boolean, whether or not the current character is being escaped
             // applicable when we are currently in a string
             let isEscaped = false;
@@ -183,7 +183,7 @@ export default class PythonIndent {
                     numConsecutiveStringDelimiters += 1;
                 } else if (checkNextCharForString) {
                     numConsecutiveStringDelimiters = 0;
-                    stringDelimiter = [];
+                    stringDelimiter = null;
                 } else {
                     numConsecutiveStringDelimiters = 0;
                 }

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -320,13 +320,24 @@ describe("python-indent", () => {
             x = [0, 1, 2,
                  4, 5, 6]
             */
-            it("handles a single delimiter inside a triple quoted string of the same delimiter", () => {
+            it("handles a single delimiter inside a triple quoted string of the same char", () => {
                 editor.insertText("\"\"\"\n");
                 editor.insertText("Here is just one quote: \"\n");
                 editor.insertText("\"\"\"\n");
                 editor.insertText("x = [0, 1, 2,\n");
                 pythonIndent.indent();
                 expect(buffer.lineForRow(4)).toBe(" ".repeat(5));
+            });
+
+            /*
+            x = ""
+            a = [b]
+            */
+            it("does not break formatting when an empty string is in the editor", () => {
+                editor.insertText("x = \"\"\n");
+                editor.insertText("a = [b,\n");
+                pythonIndent.indent();
+                expect(buffer.lineForRow(2)).toBe(" ".repeat(5));
             });
 
             /*

--- a/spec/test_file.py
+++ b/spec/test_file.py
@@ -103,4 +103,8 @@ Here is just one quote: '
 x = [0, 1, 2,
      4, 5, 6]
 
+# Problem with empty string
+x = ""
+a = [b,]
+
 class DoesBadlyFormedCodeBreak )


### PR DESCRIPTION
When an empty string `""` was anywhere in a file, the indentation would
fail because the `checkNextCharForString` variable was being reset on
each line, causing the parsing function to believe indentation was
occurring within a non-terminated string (like a multi-line
triple-quote). This variable instead should be in the context of the
parse function, not just a single line.

The regression was caused by another fix that was made in #34 for
comment characters in a triple-quoted string.

This fixes #35.