### PR TITLE
Assure indentation is occurring in an editor pane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ os:
   - linux
   - osx
 
+dist: trusty
+
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
@@ -39,4 +41,5 @@ addons:
     - build-essential
     - git
     - libgnome-keyring-dev
+    - libsecret-1-dev
     - fakeroot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.0.3] - 2017-06-01
 ### Changed
 - Update Travis CI configuration to latest [suggested](https://github.com/atom/ci/)) Atom package standard.
+### Fixed
+- Assure indentation is occurring in an editor pane. This fixed #39.
 
 ## [1.0.2] - 2017-03-15
 ### Fixed
@@ -122,7 +126,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/DSpeckhals/python-indent/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/DSpeckhals/python-indent/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/DSpeckhals/python-indent/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/DSpeckhals/python-indent/compare/v0.4.3...v1.0.0

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -6,7 +6,8 @@ export default class PythonIndent {
         this.editor = atom.workspace.getActiveTextEditor();
 
         // Make sure this is a Python file
-        if (this.editor.getGrammar().scopeName.substring(0, 13) !== "source.python") {
+        if (!this.editor ||
+            this.editor.getGrammar().scopeName.substring(0, 13) !== "source.python") {
             return;
         }
 


### PR DESCRIPTION
With the introduction of docks in Atom 1.18, the package was still
trying to perform indentation in a dock (such as the Git dock). This
commit assures that there is an active text editor before trying to
perform indentation.

This fixes #39.