### PR TITLE
WIP: Reindent feature

### DIFF
--- a/keymaps/python-indent.cson
+++ b/keymaps/python-indent.cson
@@ -1,0 +1,2 @@
+'atom-text-editor':
+  'ctrl-alt-r': 'python-indent:reindent'

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,5 +21,7 @@ export default {
         this.subscriptions = new CompositeDisposable();
         this.subscriptions.add(atom.commands.add("atom-text-editor",
             { "editor:newline": () => this.pythonIndent.indent() }));
+        this.subscriptions.add(atom.commands.add("atom-text-editor",
+            { "python-indent:reindent": () => this.pythonIndent.reindent() }));
     },
 };

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -298,6 +298,12 @@ export default class PythonIndent {
     reindent() {
         this.editor = atom.workspace.getActiveTextEditor();
 
+        if (!this.editor ||
+            this.editor.getGrammar().scopeName.substring(0, 13) !== "source.python" ||
+            !this.editor.getSoftTabs()) {
+            return;
+        }
+
         let selectedText = this.editor.getSelectedText();
 
         // if last char is newline, remove it.

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -137,6 +137,8 @@ export default class PythonIndent {
         const startRange = [row, 0];
         const stopRange = [row, this.editor.indentationForBufferRow(row) * tabLength];
         this.editor.getBuffer().setTextInRange([startRange, stopRange], indent);
+
+        return;
     }
 
     static parseLines(lines) {
@@ -293,5 +295,42 @@ export default class PythonIndent {
 
         // Set the indent
         this.editor.setIndentationForBufferRow(row, indent);
+    }
+
+    reindent() {
+        this.editor = atom.workspace.getActiveTextEditor();
+
+        let selectedText = this.editor.getSelectedText()
+
+        // if last char is newline, remove it.
+        if (selectedText[selectedText.length - 1] === "\n") {
+            selectedText = selectedText.slice(0, -1)
+        }
+
+        let selectedTextLines = selectedText.split("\n")
+
+        if (!selectedTextLines.length) {
+            return;
+        }
+
+        let {start, stop} = this.editor.getSelectedBufferRange()
+
+        // Delete the currently selected text. The documentation says:
+        //    For *each* selection, if the selection is empty,
+        //    delete the character following the cursor.
+        //    Otherwise delete the selected text.
+        // but the documentation for editor.getSelectedText() says:
+        //    Get the selected text of the *most recently added* selection.
+        // (emphasis mine in both quotes) so that's a little concerning...
+        this.editor.delete()
+
+        const tabLen = this.editor.getTabLength()
+
+        for (let row = 0; row < selectedTextLines.length; row += 1) {
+            const line = selectedTextLines[row];
+            this.editor.insertText(line.trim())
+            let editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
+            atom.commands.dispatch(editorElement, "editor:newline");
+        }
     }
 }

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -137,8 +137,6 @@ export default class PythonIndent {
         const startRange = [row, 0];
         const stopRange = [row, this.editor.indentationForBufferRow(row) * tabLength];
         this.editor.getBuffer().setTextInRange([startRange, stopRange], indent);
-
-        return;
     }
 
     static parseLines(lines) {
@@ -300,20 +298,18 @@ export default class PythonIndent {
     reindent() {
         this.editor = atom.workspace.getActiveTextEditor();
 
-        let selectedText = this.editor.getSelectedText()
+        let selectedText = this.editor.getSelectedText();
 
         // if last char is newline, remove it.
         if (selectedText[selectedText.length - 1] === "\n") {
-            selectedText = selectedText.slice(0, -1)
+            selectedText = selectedText.slice(0, -1);
         }
 
-        let selectedTextLines = selectedText.split("\n")
+        const selectedTextLines = selectedText.split("\n");
 
         if (!selectedTextLines.length) {
             return;
         }
-
-        let {start, stop} = this.editor.getSelectedBufferRange()
 
         // Delete the currently selected text. The documentation says:
         //    For *each* selection, if the selection is empty,
@@ -322,14 +318,12 @@ export default class PythonIndent {
         // but the documentation for editor.getSelectedText() says:
         //    Get the selected text of the *most recently added* selection.
         // (emphasis mine in both quotes) so that's a little concerning...
-        this.editor.delete()
-
-        const tabLen = this.editor.getTabLength()
+        this.editor.delete();
 
         for (let row = 0; row < selectedTextLines.length; row += 1) {
             const line = selectedTextLines[row];
-            this.editor.insertText(line.trim())
-            let editorElement = atom.views.getView(atom.workspace.getActiveTextEditor())
+            this.editor.insertText(line.trim());
+            const editorElement = atom.views.getView(atom.workspace.getActiveTextEditor());
             atom.commands.dispatch(editorElement, "editor:newline");
         }
     }


### PR DESCRIPTION
# Summary
Attempting to add a "reindent" feature.

I often find myself changing the name of something which ends up changing the PEP8 indentation. E.g.

```python
def fun_name(arg1,
             arg2):
```

might get changed to

```python
def my_fun_name(arg1,
             arg2):
```

and then I have to manually re-hit enter on these lines. It would be nice to have a command to re-indent automagically.

## TODO

This is a work in progress b/c it's broken in some cases. It has problems with places that should dedent, e.g. it breaks on

```python
def test(param_a, param_b, param_c,
         param_d):
    pass

def test(param_a,
         param_b,
         param_c):
    pass

class TheClass(object):
    def test(param_a, param_b,
             param_c):
        a_list = ["1", "2", "3",
                  "4"]
```
by changing it to
```python
def test(param_a, param_b, param_c,
         param_d):
    pass

    def test(param_a,
             param_b,
             param_c):
        pass

        class TheClass(object):
            def test(param_a, param_b,
                     param_c):
                a_list = ["1", "2", "3",
                          "4"]

```