### PR TITLE
Fix hanging indent error in the beta channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.2] - 2017-10-07
+- Fix hanging indentation error because of API changes to getting the "decreaseNextIndent"
+regular expression pattern. Nothing changes from users of Atom < 1.22, while users with
+newer versions will notice the fix (and a very slight optimization). This fixed #51.
+
 ## [1.1.1] - 2017-09-26
 ### Fixed
 - Fix improper hanging indentation caused by an Atom 1.19 regression. This fixed #47.
@@ -138,7 +143,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/DSpeckhals/python-indent/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/DSpeckhals/python-indent/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/DSpeckhals/python-indent/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/DSpeckhals/python-indent/compare/v1.0.2...v1.0.3

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -1,6 +1,9 @@
 "use babel";
 
 export default class PythonIndent {
+    constructor() {
+        this.version = atom.getVersion().split(".").slice(0, 2).map(p => parseInt(p, 10));
+    }
 
     indent() {
         this.editor = atom.workspace.getActiveTextEditor();
@@ -291,21 +294,33 @@ export default class PythonIndent {
         let indent = (this.editor.indentationForBufferRow(row)) +
             (atom.config.get("python-indent.hangingIndentTabs"));
 
-        // If the line where a newline was hit passes the DecreaseNextIndentPattern
-        // regex, then Atom will automatically decrease the indent on the next line
-        // but we don't actually want that since we're going to continue doing stuff
-        // on the next line.
-        const scope = this.editor.getRootScopeDescriptor();
-        const decreaseIndentPattern = this.editor.getDecreaseNextIndentPattern(scope);
-        const re = new RegExp(decreaseIndentPattern);
+        // Use the old version of the "decreaseNextIndent" for Atom < 1.22
+        if (this.version[0] === 1 && this.version[1] < 22) {
+            // If the line where a newline was hit passes the DecreaseNextIndentPattern
+            // regex, then Atom will automatically decrease the indent on the next line
+            // but we don't actually want that since we're going to continue doing stuff
+            // on the next line.
+            const scope = this.editor.getRootScopeDescriptor();
+            const decreaseIndentPattern = this.editor.getDecreaseNextIndentPattern(scope);
+            const re = new RegExp(decreaseIndentPattern);
 
-        if (re.test(this.editor.lineTextForBufferRow(row - 1))) {
-            indent += 1;
-            if (row + 1 <= this.editor.buffer.getLastRow()) {
-                // If row+1 is a valid row, then that will also have been
-                // dedented, so we need to fix that too.
-                this.editor.setIndentationForBufferRow(row + 1,
-                    this.editor.indentationForBufferRow(row + 1) + 1);
+            if (re.test(this.editor.lineTextForBufferRow(row - 1))) {
+                indent += 1;
+                if (row + 1 <= this.editor.buffer.getLastRow()) {
+                    // If row+1 is a valid row, then that will also have been
+                    // dedented, so we need to fix that too.
+                    this.editor.setIndentationForBufferRow(row + 1,
+                        this.editor.indentationForBufferRow(row + 1) + 1);
+                }
+            }
+        // Atom >= 1.22
+        } else {
+            const re = this.editor.tokenizedBuffer.decreaseNextIndentRegexForScopeDescriptor(
+                this.editor.getRootScopeDescriptor());
+
+            // If this is a "decrease next indent" line, then indent more
+            if (re.testSync(this.editor.lineTextForBufferRow(row - 1))) {
+                indent += 1;
             }
         }
 

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -224,36 +224,6 @@ describe("python-indent", () => {
             });
 
             /*
-            def test(x):
-                return (
-                    x
-                )
-            */
-            it("does not dedent too much when doing hanging indent w/ return", () => {
-                editor.insertText("def test(x):\n");
-                pythonIndent.indent();
-                expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
-                editor.insertText("return (\n");
-                pythonIndent.indent();
-                expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
-            });
-
-            /*
-            def test(x):
-                yield (
-                    x
-                )
-            */
-            it("does not dedent too much when doing hanging indent w/ return", () => {
-                editor.insertText("def test(x):\n");
-                pythonIndent.indent();
-                expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
-                editor.insertText("yield (\n");
-                pythonIndent.indent();
-                expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
-            });
-
-            /*
             class TheClass(object):
                     def test(param_a, param_b,
                              param_c):
@@ -504,6 +474,36 @@ describe("python-indent", () => {
                 editor.insertText("param_b,\n");
                 editor.autoIndentSelectedRows(3);
                 expect(buffer.lineForRow(3)).toBe(" ".repeat(4));
+            });
+
+            /*
+            def test(x):
+                return (
+                    x
+                )
+            */
+            it("does not dedent too much when doing hanging indent w/ return", () => {
+                editor.insertText("def test(x):\n");
+                pythonIndent.indent();
+                expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
+                editor.insertText("return (\n");
+                pythonIndent.indent();
+                expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
+            });
+
+            /*
+            def test(x):
+                yield (
+                    x
+                )
+            */
+            it("does not dedent too much when doing hanging indent w/ return", () => {
+                editor.insertText("def test(x):\n");
+                pythonIndent.indent();
+                expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
+                editor.insertText("yield (\n");
+                pythonIndent.indent();
+                expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
             });
 
             /*


### PR DESCRIPTION
Fix hanging indentation error because of API changes to getting the
"decreaseNextIndent" regular expression pattern. Nothing changes
from users of Atom < 1.22, while users with newer versions will
notice the fix (and a very slight optimization).

This fixes #51.