### PR TITLE
 handle edge case w/ bracket pair on same line

### DIFF
--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -9,14 +9,12 @@ export default class PythonIndent {
         // Group operations together. Most noticeable for hanging
         // indents. Note this still does not group the original
         // newline call so there's two ctrl-z's needed.
-        atom.workspace.getActiveTextEditor().transact(
-            () => {
-                this._indent();
-            }
-        )
+        atom.workspace.getActiveTextEditor().transact(() => {
+            this.indentNoTransaction();
+        });
     }
 
-    _indent() {
+    indentNoTransaction() {
         this.editor = atom.workspace.getActiveTextEditor();
 
         // Make sure this is a Python file
@@ -286,7 +284,7 @@ export default class PythonIndent {
                     if (c === ":") {
                         lastColonRow = row;
                     } else if ("})]".includes(c) && openBracketStack.length) {
-                        let openedRow = openBracketStack.pop()[0];
+                        const openedRow = openBracketStack.pop()[0];
                         // lastClosedRow is used to set the indentation back to what it was
                         // on the line when the corresponding bracket was opened. However,
                         // if the bracket was opened on this same line, then we do not need

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -6,6 +6,17 @@ export default class PythonIndent {
     }
 
     indent() {
+        // Group operations together. Most noticeable for hanging
+        // indents. Note this still does not group the original
+        // newline call so there's two ctrl-z's needed.
+        atom.workspace.getActiveTextEditor().transact(
+            () => {
+                this._indent();
+            }
+        )
+    }
+
+    _indent() {
         this.editor = atom.workspace.getActiveTextEditor();
 
         // Make sure this is a Python file
@@ -259,7 +270,7 @@ export default class PythonIndent {
                     break;
                 } else {
                     // We've already skipped if the character was white-space, an opening
-                    // bracket, or a new line, so that means the current character is not
+                    // bracket, or a comment, so that means the current character is not
                     // whitespace and not an opening bracket, so shouldHang needs to get set to
                     // false.
                     shouldHang = false;
@@ -275,9 +286,25 @@ export default class PythonIndent {
                     if (c === ":") {
                         lastColonRow = row;
                     } else if ("})]".includes(c) && openBracketStack.length) {
-                        // The .pop() will take the element off of the openBracketStack as it
-                        // adds it to the array for lastClosedRow.
-                        lastClosedRow = [openBracketStack.pop()[0], row];
+                        let openedRow = openBracketStack.pop()[0];
+                        // lastClosedRow is used to set the indentation back to what it was
+                        // on the line when the corresponding bracket was opened. However,
+                        // if the bracket was opened on this same line, then we do not need
+                        // or want to do that, and in fact, it can obscure other earlier
+                        // bracket pairs. E.g.:
+                        //   def f(api):
+                        //       (api
+                        //        .doSomething()
+                        //        .anotherThing()
+                        //        ).finish()
+                        //       print('Correctly indented!')
+                        // without the following check, the print statement would be indented
+                        // 5 spaces instead of 4.
+                        if (row !== openedRow) {
+                            // The .pop() will take the element off of the openBracketStack
+                            // as it adds it to the array for lastClosedRow.
+                            lastClosedRow = [openedRow, row];
+                        }
                     } else if ("'\"".includes(c)) {
                         // Starting a string, keep track of what quote was used to start it.
                         stringDelimiter = c;

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -301,8 +301,6 @@ export default class PythonIndent {
                         // without the following check, the print statement would be indented
                         // 5 spaces instead of 4.
                         if (row !== openedRow) {
-                            // The .pop() will take the element off of the openBracketStack
-                            // as it adds it to the array for lastClosedRow.
                             lastClosedRow = [openedRow, row];
                         }
                     } else if ("'\"".includes(c)) {

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -7,11 +7,17 @@ describe("python-indent", () => {
     let buffer = null;
     let editor = null;
     let pythonIndent = null;
+    let makeNewline = null;
 
     beforeEach(() => {
         waitsForPromise(() =>
             atom.workspace.open(FILE_NAME).then((ed) => {
                 editor = ed;
+                makeNewline = () => {
+                    atom.commands.dispatch(
+                        atom.views.getView(editor),
+                        "editor:newline");
+                    }
                 editor.setSoftTabs(true);
                 editor.setTabLength(4);
                 buffer = editor.buffer;
@@ -83,7 +89,7 @@ describe("python-indent", () => {
             x = [0, 1, 2, [3, 4, 5,
                            6, 7, 8]]
             */
-            it("indeents in nested lists when inner list is on the same line", () => {
+            it("indents in nested lists when inner list is on the same line", () => {
                 editor.insertText("x = [0, 1, 2, [3, 4, 5,\n");
                 pythonIndent.indent();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(15));
@@ -94,7 +100,7 @@ describe("python-indent", () => {
                  [3, 4, 5,
                   6, 7, 8]]
             */
-            it("indeents in nested lists when inner list is on a new line", () => {
+            it("indents in nested lists when inner list is on a new line", () => {
                 editor.insertText("x = [0, 1, 2,\n");
                 pythonIndent.indent();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(5));
@@ -199,13 +205,12 @@ describe("python-indent", () => {
             });
 
             /*
-            def test(param_a, param_b, param_c,
-                     param_d):
+            def test(param_a, param_b, param_c):
                     pass
             */
             it("indents normally when delimiter is closed", () => {
-                editor.insertText("def test(param_a, param_b, param_c):\n");
-                pythonIndent.indent();
+                editor.insertText("def test(param_a, param_b, param_c):");
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
             });
 
@@ -274,20 +279,20 @@ describe("python-indent", () => {
                         return x * i * j
             */
             it("indents properly when blocks and lists are deeply nested", () => {
-                editor.insertText("for i in range(10):\n");
-                pythonIndent.indent();
+                editor.insertText("for i in range(10):");
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
 
-                editor.insertText("for j in range(20):\n");
-                editor.autoIndentSelectedRows(2);
+                editor.insertText("for j in range(20):");
+                makeNewline();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
 
-                editor.insertText("def f(x=[0,1,2,\n");
-                pythonIndent.indent();
+                editor.insertText("def f(x=[0,1,2,");
+                makeNewline();
                 expect(buffer.lineForRow(3)).toBe(" ".repeat(17));
 
-                editor.insertText("3,4,5]):\n");
-                pythonIndent.indent();
+                editor.insertText("3,4,5]):");
+                makeNewline();
                 expect(buffer.lineForRow(4)).toBe(" ".repeat(12));
             });
 
@@ -420,6 +425,40 @@ describe("python-indent", () => {
                 pythonIndent.indent();
                 expect(buffer.lineForRow(1)).toBe("");
             });
+
+            /*
+            def test(x):
+                return [x[0], x[-1]]
+            */
+            it("unindents after return statement with same-line opened/closed brackets", () => {
+                editor.insertText("def test(x):");
+                makeNewline();
+                editor.insertText("return [x[0], x[-1]]");
+                makeNewline();
+                expect(buffer.lineForRow(2)).toBe("")
+            });
+
+            /*
+            def f(api):
+                (api
+                 .doSomething()
+                 .anotherThing()
+                 ).finish()
+                print('Correctly indented!')
+            */
+            it ("unindents correctly with same-line opened/closed brackets", () => {
+                editor.insertText("def f(api):");
+                makeNewline();
+                editor.insertText("(api");
+                makeNewline();
+                editor.insertText(".doSomething()");
+                makeNewline();
+                editor.insertText(".anotherThing()");
+                makeNewline();
+                editor.insertText(").finish()");
+                makeNewline();
+                expect(buffer.lineForRow(5)).toBe(" ".repeat(4));
+            });
         });
     });
 
@@ -483,12 +522,32 @@ describe("python-indent", () => {
                 )
             */
             it("does not dedent too much when doing hanging indent w/ return", () => {
-                editor.insertText("def test(x):\n");
-                pythonIndent.indent();
+                editor.insertText("def test(x):");
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
-                editor.insertText("return (\n");
-                pythonIndent.indent();
+                editor.insertText("return (");
+                makeNewline();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
+            });
+
+            /*
+            def test(x):
+                return (
+                    x
+                )
+            */
+            xit("correctly hanging indents return w/ newline between parentheses", () => {
+                // This test is skipped because it does not work for unknown
+                // reasons. The second makeNewline() call behaves differently
+                // during test running than when I call the exact same steps
+                // in the dev tools.
+                editor.insertText("def test(x):");
+                makeNewline();
+                editor.insertText('return ()')
+                editor.setCursorBufferPosition([1, editor.buffer.lineForRow(1).length-1]);
+                makeNewline();
+                expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
+                expect(buffer.lineForRow(3)).toBe(" ".repeat(4).concat(')'));
             });
 
             /*
@@ -498,11 +557,11 @@ describe("python-indent", () => {
                 )
             */
             it("does not dedent too much when doing hanging indent w/ return", () => {
-                editor.insertText("def test(x):\n");
-                pythonIndent.indent();
+                editor.insertText("def test(x):");
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
-                editor.insertText("yield (\n");
-                pythonIndent.indent();
+                editor.insertText("yield (");
+                makeNewline();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
             });
 
@@ -594,10 +653,10 @@ describe("python-indent", () => {
             )
             */
             it("continues correctly after bracket is opened and closed on same line", () => {
-                editor.insertText("alpha = (\n");
-                pythonIndent.indent();
-                editor.insertText("epsilon(),\n");
-                pythonIndent.indent();
+                editor.insertText("alpha = (");
+                makeNewline();
+                editor.insertText("epsilon(),");
+                makeNewline();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(4));
             });
 

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -17,7 +17,7 @@ describe("python-indent", () => {
                     atom.commands.dispatch(
                         atom.views.getView(editor),
                         "editor:newline");
-                    }
+                };
                 editor.setSoftTabs(true);
                 editor.setTabLength(4);
                 buffer = editor.buffer;
@@ -435,7 +435,7 @@ describe("python-indent", () => {
                 makeNewline();
                 editor.insertText("return [x[0], x[-1]]");
                 makeNewline();
-                expect(buffer.lineForRow(2)).toBe("")
+                expect(buffer.lineForRow(2)).toBe("");
             });
 
             /*
@@ -446,7 +446,7 @@ describe("python-indent", () => {
                  ).finish()
                 print('Correctly indented!')
             */
-            it ("unindents correctly with same-line opened/closed brackets", () => {
+            it("unindents correctly with same-line opened/closed brackets", () => {
                 editor.insertText("def f(api):");
                 makeNewline();
                 editor.insertText("(api");
@@ -543,11 +543,11 @@ describe("python-indent", () => {
                 // in the dev tools.
                 editor.insertText("def test(x):");
                 makeNewline();
-                editor.insertText('return ()')
-                editor.setCursorBufferPosition([1, editor.buffer.lineForRow(1).length-1]);
+                editor.insertText("return ()");
+                editor.setCursorBufferPosition([1, editor.buffer.lineForRow(1).length - 1]);
                 makeNewline();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
-                expect(buffer.lineForRow(3)).toBe(" ".repeat(4).concat(')'));
+                expect(buffer.lineForRow(3)).toBe(" ".repeat(4).concat(")"));
             });
 
             /*

--- a/spec/test_file.py
+++ b/spec/test_file.py
@@ -13,6 +13,13 @@ x = [[[0,1,2],
       3,4,5],
      6,7,8]
 
+def f(api):
+    (api
+     .doSomething()
+     .anotherThing()
+     ).finish()
+    print('Correctly indented!')
+
 x = [0, 1, 2,
      [3, 4, 5,
       6, 7, 8]]
@@ -56,6 +63,9 @@ def test(x):
     return (
         x
     )
+
+def test(x):
+    return [x[0], x[-1]]
 
 def test(x):
     yield (


### PR DESCRIPTION
Before:

```python
def f(api):
    (api
     .doSomething()
     .anotherThing()
     ).finish()
     print('Correctly indented!')
```
(extra space in `print` line indentation)

Now:

```python
def f(api):
    (api
     .doSomething()
     .anotherThing()
     ).finish()
    print('Correctly indented!')
```