### PR TITLE
Handle missing "decreaseNextIndent" pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.1.3] - 2017-11-09
+# Fixed
+- Fix scenario that happens in Atom 1.23 and newer (currently only Beta) where
+language-python removed the "decreaseNextIndent" pattern. This fixed #54.
 - Handle edge case with bracket pair on same line.
 
 ## [1.1.2] - 2017-10-07
@@ -144,7 +149,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/DSpeckhals/python-indent/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/DSpeckhals/python-indent/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/DSpeckhals/python-indent/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/DSpeckhals/python-indent/compare/v1.0.3...v1.1.0

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -337,12 +337,14 @@ export default class PythonIndent {
                 }
             }
         // Atom >= 1.22
+        // Version 1.23 of language-python does not include the below regex.
+        // See https://github.com/atom/language-python/pull/212
         } else {
             const re = this.editor.tokenizedBuffer.decreaseNextIndentRegexForScopeDescriptor(
                 this.editor.getRootScopeDescriptor());
 
             // If this is a "decrease next indent" line, then indent more
-            if (re.testSync(this.editor.lineTextForBufferRow(row - 1))) {
+            if (re && re.testSync(this.editor.lineTextForBufferRow(row - 1))) {
                 indent += 1;
             }
         }

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -8,18 +8,21 @@ describe("python-indent", () => {
     let editor = null;
     let pythonIndent = null;
     let makeNewline = null;
+    let manualTabs = false;
 
     beforeEach(() => {
         waitsForPromise(() =>
             atom.workspace.open(FILE_NAME).then((ed) => {
+                const tabLength = 4;
                 editor = ed;
-                makeNewline = () => {
+                makeNewline = (tabs = 0) => {
                     atom.commands.dispatch(
                         atom.views.getView(editor),
                         "editor:newline");
+                    editor.insertText(" ".repeat((manualTabs ? tabs : 0) * tabLength));
                 };
                 editor.setSoftTabs(true);
-                editor.setTabLength(4);
+                editor.setTabLength(tabLength);
                 buffer = editor.buffer;
             }),
         );
@@ -40,6 +43,7 @@ describe("python-indent", () => {
         waitsForPromise(() =>
             atom.packages.activatePackage("python-indent").then(() => {
                 pythonIndent = new PythonIndent();
+                manualTabs = pythonIndent.version[1] > 22;
             }),
         );
     });
@@ -210,7 +214,7 @@ describe("python-indent", () => {
             */
             it("indents normally when delimiter is closed", () => {
                 editor.insertText("def test(param_a, param_b, param_c):");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
             });
 
@@ -280,11 +284,11 @@ describe("python-indent", () => {
             */
             it("indents properly when blocks and lists are deeply nested", () => {
                 editor.insertText("for i in range(10):");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
 
                 editor.insertText("for j in range(20):");
-                makeNewline();
+                makeNewline(2);
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
 
                 editor.insertText("def f(x=[0,1,2,");
@@ -456,7 +460,7 @@ describe("python-indent", () => {
                 editor.insertText(".anotherThing()");
                 makeNewline();
                 editor.insertText(").finish()");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(5)).toBe(" ".repeat(4));
             });
         });
@@ -523,10 +527,10 @@ describe("python-indent", () => {
             */
             it("does not dedent too much when doing hanging indent w/ return", () => {
                 editor.insertText("def test(x):");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
                 editor.insertText("return (");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
             });
 
@@ -558,10 +562,10 @@ describe("python-indent", () => {
             */
             it("does not dedent too much when doing hanging indent w/ return", () => {
                 editor.insertText("def test(x):");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
                 editor.insertText("yield (");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
             });
 
@@ -656,7 +660,7 @@ describe("python-indent", () => {
                 editor.insertText("alpha = (");
                 makeNewline();
                 editor.insertText("epsilon(),");
-                makeNewline();
+                makeNewline(1);
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(4));
             });
 


### PR DESCRIPTION
This pattern was recently removed from language-python. See https://github.com/atom/language-python/pull/212.

This commit handles that scenario, as well as fixes tests surrounding it. Other tests were adjusted to handle Atom not auto-inserting the indentation for several scenarios where we are currently using the
`makeNewline` function. The tabs to indent (which are always a multiple of the editor's tab length) can be passed. This only happens on Atom > 1.23. There is probably a better solution for this in the long term.

cc: @kbrose 