### PR TITLE
Fix error thrown from non-active text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.4] - 2017-11-09
+# Fixed
+- Fix error when typing in a "non-active" text editor (like the Git panel) after
+this package activates.
+
 ## [1.1.3] - 2017-11-09
 # Fixed
 - Fix scenario that happens in Atom 1.23 and newer (currently only Beta) where
@@ -149,7 +154,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/DSpeckhals/python-indent/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/DSpeckhals/python-indent/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/DSpeckhals/python-indent/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/DSpeckhals/python-indent/compare/v1.1.0...v1.1.1

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -6,15 +6,6 @@ export default class PythonIndent {
     }
 
     indent() {
-        // Group operations together. Most noticeable for hanging
-        // indents. Note this still does not group the original
-        // newline call so there's two ctrl-z's needed.
-        atom.workspace.getActiveTextEditor().transact(() => {
-            this.indentNoTransaction();
-        });
-    }
-
-    indentNoTransaction() {
         this.editor = atom.workspace.getActiveTextEditor();
 
         // Make sure this is a Python file
@@ -24,6 +15,15 @@ export default class PythonIndent {
             return;
         }
 
+        // Group operations together. Most noticeable for hanging
+        // indents. Note this still does not group the original
+        // newline call so there's two ctrl-z's needed.
+        this.editor.transact(() => {
+            this.indentNoTransaction();
+        });
+    }
+
+    indentNoTransaction() {
         // Get base variables
         const row = this.editor.getCursorBufferPosition().row;
         const col = this.editor.getCursorBufferPosition().column;


### PR DESCRIPTION
After this package activates, if editing a non-active text editor (like a git commit message editor), an error could be thrown. This commit makes sure that there is an active editor before attempting to run
`transact`.

This fixes #56.