### PR TITLE
Allow new tree-sitter functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,12 @@ git:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:
     - build-essential
-    - git
-    - libgnome-keyring-dev
-    - libsecret-1-dev
     - fakeroot
+    - git
+    - libsecret-1-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.5] - 2018-03-29
+# Fixed
+- Allow for the new tree-sitter parser's grammar for language-python to be used.
+
 ## [1.1.4] - 2017-11-09
 # Fixed
 - Fix error when typing in a "non-active" text editor (like the Git panel) after

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2017 Dustin Speckhals
+Copyright (c) 2016-2018 Dustin Speckhals
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -8,9 +8,15 @@ export default class PythonIndent {
     indent() {
         this.editor = atom.workspace.getActiveTextEditor();
 
+        // Make sure there's an active editor
+        if (!this.editor) {
+            return;
+        }
+
         // Make sure this is a Python file
-        if (!this.editor ||
-            this.editor.getGrammar().scopeName.substring(0, 13) !== "source.python" ||
+        const scopeName = this.editor.getGrammar().scopeName;
+        if ((scopeName !== "python" && // New grammar name
+            scopeName.substring(0, 13) !== "source.python") || // Legacy grammar name
             !this.editor.getSoftTabs()) {
             return;
         }


### PR DESCRIPTION
This commit adds the newer `scopeName` for Python. With the new syntax
parsing implemented with Tree Sitter
(https://github.com/atom/atom/pull/16299, https://github.com/atom/language-python/pull/220),
this new scope name was added. Otherwise, the indentation seems to work as expected.

This fixes #60.