### PR TITLE
Separate parser out into an NPM package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "airbnb-base",
+    "extends": "airbnb",
     "env": {
         "jasmine": true
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- __Breaking__ Remove support for versions of Atom before 1.22.
+- Separate out the parsing into a different library to allow other editors to
+use its base functionality.
 
 ## [1.1.7] - 2019-02-08
 ### Security

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2018 Dustin Speckhals
+Copyright (c) 2016-2019 Dustin Speckhals
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -1,5 +1,7 @@
 "use babel";
 
+import * as parser from "python-indent-parser";
+
 export default class PythonIndent {
     constructor() {
         this.version = atom.getVersion().split(".").slice(0, 2).map(p => parseInt(p, 10));
@@ -27,341 +29,31 @@ export default class PythonIndent {
         // indents. Note this still does not group the original
         // newline call so there's two ctrl-z's needed.
         this.editor.transact(() => {
-            this.indentNoTransaction();
+            const { row, column: col } = this.editor.getCursorBufferPosition();
+            const tabSize = this.editor.getTabLength();
+            const lines = this.editor.getTextInBufferRange([[0, 0], [row, col]]).split("\n");
+
+            // The parser assumes not to have the line after the new line character.
+            lines.pop();
+
+            const { nextIndentationLevel, canHang } = parser.indentationInfo(lines, tabSize);
+            if (canHang) {
+                const indent = this.editor.indentationForBufferRow(row)
+                    + atom.config.get("python-indent.hangingIndentTabs");
+
+                this.editor.setIndentationForBufferRow(row, indent);
+                return;
+            }
+
+            // Create the indentation string.
+            const toInsert = `${" ".repeat(Math.max(nextIndentationLevel, 0))}`;
+            const range = [[row, 0], [row, this.editor.indentationForBufferRow(row) * tabSize]];
+
+            // Only set the new indent if it's different than what the editor chose.
+            const currentIndent = this.editor.getTextInBufferRange(range);
+            if (currentIndent !== toInsert) {
+                this.editor.getBuffer().setTextInRange(range, toInsert);
+            }
         });
-    }
-
-    indentNoTransaction() {
-        // Get base variables
-        const { row, column: col } = this.editor.getCursorBufferPosition();
-
-        // Parse the entire file up to the current point, keeping track of brackets
-        let lines = this.editor.getTextInBufferRange([[0, 0], [row, col]]).split("\n");
-        // At this point, the newline character has just been added,
-        // so remove the last element of lines, which will be the empty line
-        lines = lines.splice(0, lines.length - 1);
-
-        const parseOutput = PythonIndent.parseLines(lines);
-        // openBracketStack: A stack of [row, col] pairs describing where open brackets are
-        // lastClosedRow: Either empty, or an array [rowOpen, rowClose] describing the rows
-        //     where the last bracket to be closed was opened and closed.
-        // shouldHang: Boolean, indicating whether or not a hanging indent is needed.
-        // lastColonRow: The last row a def/for/if/elif/else/try/except etc. block started
-        const {
-            openBracketStack, lastClosedRow, shouldHang, lastColonRow,
-        } = parseOutput;
-
-        if (shouldHang) {
-            this.indentHanging(row, this.editor.buffer.lineForRow(row - 1));
-            return;
-        }
-
-        if (!(openBracketStack.length || (lastClosedRow.length && openBracketStack))) {
-            return;
-        }
-
-        if (!openBracketStack.length) {
-            // Can assume lastClosedRow is not empty
-            if (lastClosedRow[1] === row - 1) {
-                // We just closed a bracket on the row, get indentation from the
-                // row where it was opened
-                let indentLevel = this.editor.indentationForBufferRow(lastClosedRow[0]);
-
-                if (lastColonRow === row - 1) {
-                    // We just finished def/for/if/elif/else/try/except etc. block,
-                    // need to increase indent level by 1.
-                    indentLevel += 1;
-                }
-                this.editor.setIndentationForBufferRow(row, indentLevel);
-            }
-            return;
-        }
-
-        // Get tab length for context
-        const tabLength = this.editor.getTabLength();
-
-        const lastOpenBracketLocations = openBracketStack.pop();
-
-        // Get some booleans to help work through the cases
-
-        // haveClosedBracket is true if we have ever closed a bracket
-        const haveClosedBracket = lastClosedRow.length;
-        // justOpenedBracket is true if we opened a bracket on the row we just finished
-        const justOpenedBracket = lastOpenBracketLocations[0] === row - 1;
-        // justClosedBracket is true if we closed a bracket on the row we just finished
-        const justClosedBracket = haveClosedBracket && lastClosedRow[1] === row - 1;
-        // closedBracketOpenedAfterLineWithCurrentOpen is an ***extremely*** long name, and
-        // it is true if the most recently closed bracket pair was opened on
-        // a line AFTER the line where the current open bracket
-        const closedBracketOpenedAfterLineWithCurrentOpen = haveClosedBracket
-            && lastClosedRow[0] > lastOpenBracketLocations[0];
-        let indentColumn;
-
-        if (!justOpenedBracket && !justClosedBracket) {
-            // The bracket was opened before the previous line,
-            // and we did not close a bracket on the previous line.
-            // Thus, nothing has happened that could have changed the
-            // indentation level since the previous line, so
-            // we should use whatever indent we are given.
-            return;
-        } if (justClosedBracket && closedBracketOpenedAfterLineWithCurrentOpen) {
-            // A bracket that was opened after the most recent open
-            // bracket was closed on the line we just finished typing.
-            // We should use whatever indent was used on the row
-            // where we opened the bracket we just closed. This needs
-            // to be handled as a separate case from the last case below
-            // in case the current bracket is using a hanging indent.
-            // This handles cases such as
-            // x = [0, 1, 2,
-            //      [3, 4, 5,
-            //       6, 7, 8],
-            //      9, 10, 11]
-            // which would be correctly handled by the case below, but it also correctly handles
-            // x = [
-            //     0, 1, 2, [3, 4, 5,
-            //               6, 7, 8],
-            //     9, 10, 11
-            // ]
-            // which the last case below would incorrectly indent an extra space
-            // before the "9", because it would try to match it up with the
-            // open bracket instead of using the hanging indent.
-            const previousIndent = this.editor.indentationForBufferRow(lastClosedRow[0]);
-            indentColumn = previousIndent * tabLength;
-        } else {
-            // lastOpenBracketLocations[1] is the column where the bracket was,
-            // so need to bump up the indentation by one
-            indentColumn = lastOpenBracketLocations[1] + 1;
-        }
-
-        // Calculate soft-tabs from spaces (can have remainder)
-        let tabs = indentColumn / tabLength;
-        const rem = (tabs - Math.floor(tabs)) * tabLength;
-
-        // If there's a remainder, `@editor.buildIndentString` requires the tab to
-        // be set past the desired indentation level, thus the ceiling.
-        tabs = rem > 0 ? Math.ceil(tabs) : tabs;
-
-        // Offset is the number of spaces to subtract from the soft-tabs if they
-        // are past the desired indentation (not divisible by tab length).
-        const offset = rem > 0 ? tabLength - rem : 0;
-
-        // I'm glad Atom has an optional `column` param to subtract spaces from
-        // soft-tabs, though I don't see it used anywhere in the core.
-        // It looks like for hard tabs, the "tabs" input can be fractional and
-        // the "column" input is ignored...?
-        const indent = this.editor.buildIndentString(tabs, offset);
-
-        // The range of text to replace with our indent
-        // will need to change this for hard tabs, especially tricky for when
-        // hard tabs have mixture of tabs + spaces, which they can judging from
-        // the editor.buildIndentString function
-        const startRange = [row, 0];
-        const stopRange = [row, this.editor.indentationForBufferRow(row) * tabLength];
-        this.editor.getBuffer().setTextInRange([startRange, stopRange], indent);
-    }
-
-    static parseLines(lines) {
-        // openBracketStack is an array of [row, col] indicating the location
-        // of the opening bracket (square, curly, or parentheses)
-        const openBracketStack = [];
-        // lastClosedRow is either empty or [rowOpen, rowClose] describing the
-        // rows where the latest closed bracket was opened and closed.
-        let lastClosedRow = [];
-        // If we are in a string, this tells us what character introduced the string
-        // i.e., did this string start with ' or with "?
-        let stringDelimiter = null;
-        // This is the row of the last function definition
-        let lastColonRow = NaN;
-        // true if we are in a triple quoted string
-        let inTripleQuotedString = false;
-        // If we have seen two of the same string delimiters in a row,
-        // then we have to check the next character to see if it matches
-        // in order to correctly parse triple quoted strings.
-        let checkNextCharForString = false;
-        // true if we should have a hanging indent, false otherwise
-        let shouldHang = false;
-
-        // NOTE: this parsing will only be correct if the python code is well-formed
-        // statements like "[0, (1, 2])" might break the parsing
-
-        // loop over each line
-        const linesLength = lines.length;
-        for (let row = 0; row < linesLength; row += 1) {
-            const line = lines[row];
-
-            // Keep track of the number of consecutive string delimiter's we've seen
-            // in this line; this is used to tell if we are in a triple quoted string
-            let numConsecutiveStringDelimiters = 0;
-            // boolean, whether or not the current character is being escaped
-            // applicable when we are currently in a string
-            let isEscaped = false;
-
-            // This is the last defined def/for/if/elif/else/try/except row
-            const lastlastColonRow = lastColonRow;
-            const lineLength = line.length;
-            for (let col = 0; col < lineLength; col += 1) {
-                const c = line[col];
-
-                if (c === stringDelimiter && !isEscaped) {
-                    numConsecutiveStringDelimiters += 1;
-                } else if (checkNextCharForString) {
-                    numConsecutiveStringDelimiters = 0;
-                    stringDelimiter = null;
-                } else {
-                    numConsecutiveStringDelimiters = 0;
-                }
-
-                checkNextCharForString = false;
-
-                // If stringDelimiter is set, then we are in a string
-                // Note that this works correctly even for triple quoted strings
-                if (stringDelimiter) {
-                    if (isEscaped) {
-                        // If current character is escaped, then we do not care what it was,
-                        // but since it is impossible for the next character to be escaped as well,
-                        // go ahead and set that to false
-                        isEscaped = false;
-                    } else if (c === stringDelimiter) {
-                        // We are seeing the same quote that started the string, i.e. ' or "
-                        if (inTripleQuotedString) {
-                            if (numConsecutiveStringDelimiters === 3) {
-                                // Breaking out of the triple quoted string...
-                                numConsecutiveStringDelimiters = 0;
-                                stringDelimiter = null;
-                                inTripleQuotedString = false;
-                            }
-                        } else if (numConsecutiveStringDelimiters === 3) {
-                            // reset the count, correctly handles cases like ''''''
-                            numConsecutiveStringDelimiters = 0;
-                            inTripleQuotedString = true;
-                        } else if (numConsecutiveStringDelimiters === 2) {
-                            // We are not currently in a triple quoted string, and we've
-                            // seen two of the same string delimiter in a row. This could
-                            // either be an empty string, i.e. '' or "", or it could be
-                            // the start of a triple quoted string. We will check the next
-                            // character, and if it matches then we know we're in a triple
-                            // quoted string, and if it does not match we know we're not
-                            // in a string any more (i.e. it was the empty string).
-                            checkNextCharForString = true;
-                        } else if (numConsecutiveStringDelimiters === 1) {
-                            // We are not in a string that is not triple quoted, and we've
-                            // just seen an un-escaped instance of that string delimiter.
-                            // In other words, we've left the string.
-                            // It is also worth noting that it is impossible for
-                            // numConsecutiveStringDelimiters to be 0 at this point, so
-                            // this set of if/else if statements covers all cases.
-                            stringDelimiter = null;
-                        }
-                    } else if (c === "\\") {
-                        // We are seeing an unescaped backslash, the next character is escaped.
-                        // Note that this is not exactly true in raw strings, HOWEVER, in raw
-                        // strings you can still escape the quote mark by using a backslash.
-                        // Since that's all we really care about as far as escaped characters
-                        // go, we can assume we are now escaping the next character.
-                        isEscaped = true;
-                    }
-                } else if ("[({".includes(c)) {
-                    openBracketStack.push([row, col]);
-                    // If the only characters after this opening bracket are whitespace,
-                    // then we should do a hanging indent. If there are other non-whitespace
-                    // characters after this, then they will set the shouldHang boolean to false
-                    shouldHang = true;
-                } else if (" \t\r\n".includes(c)) { // just in case there's a new line
-                    // If it's whitespace, we don't care at all
-                    // this check is necessary so we don't set shouldHang to false even if
-                    // someone e.g. just entered a space between the opening bracket and the
-                    // newline.
-                } else if (c === "#") {
-                    // This check goes as well to make sure we don't set shouldHang
-                    // to false in similar circumstances as described in the whitespace section.
-                    break;
-                } else {
-                    // We've already skipped if the character was white-space, an opening
-                    // bracket, or a comment, so that means the current character is not
-                    // whitespace and not an opening bracket, so shouldHang needs to get set to
-                    // false.
-                    shouldHang = false;
-
-                    // Similar to above, we've already skipped all irrelevant characters,
-                    // so if we saw a colon earlier in this line, then we would have
-                    // incorrectly thought it was the end of a def/for/if/elif/else/try/except
-                    // block when it was actually a dictionary being defined, reset the
-                    // lastColonRow variable to whatever it was when we started parsing this
-                    // line.
-                    lastColonRow = lastlastColonRow;
-
-                    if (c === ":") {
-                        lastColonRow = row;
-                    } else if ("})]".includes(c) && openBracketStack.length) {
-                        const openedRow = openBracketStack.pop()[0];
-                        // lastClosedRow is used to set the indentation back to what it was
-                        // on the line when the corresponding bracket was opened. However,
-                        // if the bracket was opened on this same line, then we do not need
-                        // or want to do that, and in fact, it can obscure other earlier
-                        // bracket pairs. E.g.:
-                        //   def f(api):
-                        //       (api
-                        //        .doSomething()
-                        //        .anotherThing()
-                        //        ).finish()
-                        //       print('Correctly indented!')
-                        // without the following check, the print statement would be indented
-                        // 5 spaces instead of 4.
-                        if (row !== openedRow) {
-                            lastClosedRow = [openedRow, row];
-                        }
-                    } else if ("'\"".includes(c)) {
-                        // Starting a string, keep track of what quote was used to start it.
-                        stringDelimiter = c;
-                        numConsecutiveStringDelimiters += 1;
-                    }
-                }
-            }
-        }
-        return {
-            openBracketStack, lastClosedRow, shouldHang, lastColonRow,
-        };
-    }
-
-    indentHanging(row) {
-        // Indent at the current block level plus the setting amount (1 or 2)
-        let indent = (this.editor.indentationForBufferRow(row))
-            + (atom.config.get("python-indent.hangingIndentTabs"));
-
-        // Use the old version of the "decreaseNextIndent" for Atom < 1.22
-        if (this.version[0] === 1 && this.version[1] < 22) {
-            // If the line where a newline was hit passes the DecreaseNextIndentPattern
-            // regex, then Atom will automatically decrease the indent on the next line
-            // but we don't actually want that since we're going to continue doing stuff
-            // on the next line.
-            const scope = this.editor.getRootScopeDescriptor();
-            const decreaseIndentPattern = this.editor.getDecreaseNextIndentPattern(scope);
-            const re = new RegExp(decreaseIndentPattern);
-
-            if (re.test(this.editor.lineTextForBufferRow(row - 1))) {
-                indent += 1;
-                if (row + 1 <= this.editor.buffer.getLastRow()) {
-                    // If row+1 is a valid row, then that will also have been
-                    // dedented, so we need to fix that too.
-                    this.editor.setIndentationForBufferRow(row + 1,
-                        this.editor.indentationForBufferRow(row + 1) + 1);
-                }
-            }
-        // Atom >= 1.22
-        // Version 1.23 of language-python does not include the below regex.
-        // See https://github.com/atom/language-python/pull/212
-        } else {
-            const re = this.editor.tokenizedBuffer.decreaseNextIndentRegexForScopeDescriptor(
-                this.editor.getRootScopeDescriptor(),
-            );
-
-            // If this is a "decrease next indent" line, then indent more
-            if (re && re.testSync(this.editor.lineTextForBufferRow(row - 1))) {
-                indent += 1;
-            }
-        }
-
-        // Set the indent
-        this.editor.setIndentationForBufferRow(row, indent);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,13 @@
 {
   "name": "python-indent",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.0.0"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
-      }
-    },
     "acorn": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-      "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -37,9 +17,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
-      "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -48,6 +28,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-keywords": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -55,19 +41,16 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -78,11 +61,75 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
+    },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -100,10 +147,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
     "callsites": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "chalk": {
@@ -115,12 +171,32 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
     "circular-json": {
@@ -159,6 +235,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -184,10 +266,16 @@
         "which": "^1.2.9"
       }
     },
+    "damerau-levenshtein": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
+      "dev": true
+    },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
@@ -216,6 +304,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -257,32 +351,32 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.13.0.tgz",
-      "integrity": "sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.3.0.tgz",
+      "integrity": "sha512-N/tCqlMKkyNvAvLu+zI9AqDasnSLt00K+Hu8kdsERliC9jYEc8ck12XtjvOXrBKu8fK6RrBcN9bat6Xk++9jAg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
+        "ajv": "^6.5.0",
+        "babel-code-frame": "^6.26.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
+        "debug": "^3.1.0",
         "doctrine": "^2.1.0",
         "eslint-scope": "^4.0.0",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.0",
+        "espree": "^4.0.0",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob": "^7.1.2",
         "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
+        "ignore": "^4.0.2",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "js-yaml": "^3.12.0",
+        "inquirer": "^5.2.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.11.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.5",
@@ -291,13 +385,27 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
+        "regexpp": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.0",
+        "string.prototype.matchall": "^2.0.0",
         "strip-ansi": "^4.0.0",
         "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
+        "table": "^4.0.3",
         "text-table": "^0.2.0"
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz",
+      "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^13.1.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-config-airbnb-base": {
@@ -339,9 +447,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -366,21 +474,22 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
-      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz",
+      "integrity": "sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==",
       "dev": true,
       "requires": {
+        "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.3.0",
+        "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
         "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.9.0"
+        "resolve": "^1.10.0"
       },
       "dependencies": {
         "debug": {
@@ -410,6 +519,37 @@
         }
       }
     },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+      "dev": true,
+      "requires": {
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
+      "integrity": "sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      }
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
@@ -417,9 +557,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -439,9 +579,9 @@
       "dev": true
     },
     "espree": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.2",
@@ -486,13 +626,13 @@
       "dev": true
     },
     "external-editor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
       }
     },
@@ -573,9 +713,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -587,9 +727,9 @@
       }
     },
     "globals": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
     "graceful-fs": {
@@ -605,6 +745,15 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -640,16 +789,6 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
-    "import-fresh": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
-      "dev": true,
-      "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      }
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -673,41 +812,24 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
+        "external-editor": "^2.1.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^5.5.2",
         "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
+        "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.0.0"
-          }
-        }
       }
     },
     "is-arrayish": {
@@ -749,6 +871,12 @@
         "has": "^1.0.1"
       }
     },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
@@ -768,15 +896,15 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -794,6 +922,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+      "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -832,6 +969,15 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -935,6 +1081,18 @@
         "has": "^1.0.1"
       }
     },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -996,15 +1154,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
-    },
-    "parent-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
-      "dev": true,
-      "requires": {
-        "callsites": "^3.0.0"
-      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -1069,6 +1218,12 @@
         "find-up": "^2.1.0"
       }
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1081,10 +1236,32 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "python-indent-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/python-indent-parser/-/python-indent-parser-0.1.0.tgz",
+      "integrity": "sha512-8savj6iyjEVRbkGUuHFr4GO9mXSZGVmbIuY3J8RB7Y62c3rRkIrOFpSu0UfWVlSdpqxIaBWqCvTPdqic+Ad/YA=="
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
       "dev": true
     },
     "read-pkg": {
@@ -1108,25 +1285,44 @@
         "read-pkg": "^2.0.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "restore-cursor": {
@@ -1158,12 +1354,12 @@
       }
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "symbol-observable": "1.0.1"
       }
     },
     "safer-buffer": {
@@ -1173,9 +1369,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
     "shebang-command": {
@@ -1200,13 +1396,11 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
@@ -1237,9 +1431,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "sprintf-js": {
@@ -1258,6 +1452,19 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string.prototype.matchall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
+      "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1265,6 +1472,14 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -1280,23 +1495,28 @@
       "dev": true
     },
     "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
     },
     "table": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.2.2.tgz",
-      "integrity": "sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.6.1",
-        "lodash": "^4.17.11",
-        "slice-ansi": "^2.0.0",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
       }
     },
@@ -1320,12 +1540,6 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
-    },
-    "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "python-indent",
   "main": "./lib/main",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Python PEP8 auto-indentation",
   "author": "Dustin Speckhals <dustin1114@gmail.com>",
   "keywords": [
@@ -18,11 +18,16 @@
   "repository": "https://github.com/DSpeckhals/python-indent",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.22.0 <2.0.0"
   },
   "devDependencies": {
-    "eslint": "^5.13.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.16.0"
+    "eslint": "^5.3.0",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
+    "eslint-plugin-react": "^7.13.0"
+  },
+  "dependencies": {
+    "python-indent-parser": "^0.1.0"
   }
 }

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -8,7 +8,6 @@ describe("python-indent", () => {
     let editor = null;
     let pythonIndent = null;
     let makeNewline = null;
-    let manualTabs = false;
 
     beforeEach(() => {
         waitsForPromise(() => atom.workspace.open(FILE_NAME).then((ed) => {
@@ -19,7 +18,7 @@ describe("python-indent", () => {
                     atom.views.getView(editor),
                     "editor:newline",
                 );
-                editor.insertText(" ".repeat((manualTabs ? tabs : 0) * tabLength));
+                editor.insertText(" ".repeat(tabs * tabLength));
             };
             editor.setSoftTabs(true);
             editor.setTabLength(tabLength);
@@ -42,7 +41,6 @@ describe("python-indent", () => {
 
         waitsForPromise(() => atom.packages.activatePackage("python-indent").then(() => {
             pythonIndent = new PythonIndent();
-            manualTabs = pythonIndent.version[1] > 22;
         }));
     });
 
@@ -210,7 +208,7 @@ describe("python-indent", () => {
             */
             it("indents normally when delimiter is closed", () => {
                 editor.insertText("def test(param_a, param_b, param_c):");
-                makeNewline(1);
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
             });
 
@@ -280,11 +278,11 @@ describe("python-indent", () => {
             */
             it("indents properly when blocks and lists are deeply nested", () => {
                 editor.insertText("for i in range(10):");
-                makeNewline(1);
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
 
                 editor.insertText("for j in range(20):");
-                makeNewline(2);
+                makeNewline();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(8));
 
                 editor.insertText("def f(x=[0,1,2,");
@@ -456,7 +454,7 @@ describe("python-indent", () => {
                 editor.insertText(".anotherThing()");
                 makeNewline();
                 editor.insertText(").finish()");
-                makeNewline(1);
+                makeNewline();
                 expect(buffer.lineForRow(5)).toBe(" ".repeat(4));
             });
         });
@@ -523,7 +521,7 @@ describe("python-indent", () => {
             */
             it("does not dedent too much when doing hanging indent w/ return", () => {
                 editor.insertText("def test(x):");
-                makeNewline(1);
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
                 editor.insertText("return (");
                 makeNewline(1);
@@ -556,9 +554,9 @@ describe("python-indent", () => {
                     x
                 )
             */
-            it("does not dedent too much when doing hanging indent w/ return", () => {
+            it("does not dedent too much when doing hanging indent w/ yield", () => {
                 editor.insertText("def test(x):");
-                makeNewline(1);
+                makeNewline();
                 expect(buffer.lineForRow(1)).toBe(" ".repeat(4));
                 editor.insertText("yield (");
                 makeNewline(1);
@@ -656,7 +654,7 @@ describe("python-indent", () => {
                 editor.insertText("alpha = (");
                 makeNewline();
                 editor.insertText("epsilon(),");
-                makeNewline(1);
+                makeNewline();
                 expect(buffer.lineForRow(2)).toBe(" ".repeat(4));
             });
 


### PR DESCRIPTION
This commit moves the parsing functionality into a separate package so
other editors that support JavaScript packages (namely VS Code) can hook
into it.

The new package can be viewed at https://github.com/DSpeckhals/python-indent-parser.

Fixes #65