### PR TITLE
Add support for multiple cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.1] - 2019-05-10
+### Added
+- Add support for multiple cursors. This fixed #59.
+
 ## [1.2.0] - 2019-05-10
 ### Changed
 - __Breaking__ Remove support for versions of Atom before 1.22.
@@ -172,7 +176,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.2.1...HEAD
+[1.2.0]: https://github.com/DSpeckhals/python-indent/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/DSpeckhals/python-indent/compare/v1.1.7...v1.2.0
 [1.1.7]: https://github.com/DSpeckhals/python-indent/compare/v1.1.6...v1.1.7
 [1.1.6]: https://github.com/DSpeckhals/python-indent/compare/v1.1.5...v1.1.6

--- a/lib/python-indent.js
+++ b/lib/python-indent.js
@@ -29,31 +29,34 @@ export default class PythonIndent {
         // indents. Note this still does not group the original
         // newline call so there's two ctrl-z's needed.
         this.editor.transact(() => {
-            const { row, column: col } = this.editor.getCursorBufferPosition();
-            const tabSize = this.editor.getTabLength();
-            const lines = this.editor.getTextInBufferRange([[0, 0], [row, col]]).split("\n");
+            // Loop through cursor positions to allow for multiple cursors.
+            this.editor.getCursorBufferPositions().forEach(({ row, column: col }) => {
+                const tabSize = this.editor.getTabLength();
+                const lines = this.editor.getTextInBufferRange([[0, 0], [row, col]]).split("\n");
 
-            // The parser assumes not to have the line after the new line character.
-            lines.pop();
+                // The parser assumes not to have the line after the new line character.
+                lines.pop();
 
-            const { nextIndentationLevel, canHang } = parser.indentationInfo(lines, tabSize);
-            if (canHang) {
-                const indent = this.editor.indentationForBufferRow(row)
-                    + atom.config.get("python-indent.hangingIndentTabs");
+                // Use hanging indentation if it's needed.
+                const { nextIndentationLevel, canHang } = parser.indentationInfo(lines, tabSize);
+                if (canHang) {
+                    const indent = this.editor.indentationForBufferRow(row)
+                        + atom.config.get("python-indent.hangingIndentTabs");
 
-                this.editor.setIndentationForBufferRow(row, indent);
-                return;
-            }
+                    this.editor.setIndentationForBufferRow(row, indent);
+                    return;
+                }
 
-            // Create the indentation string.
-            const toInsert = `${" ".repeat(Math.max(nextIndentationLevel, 0))}`;
-            const range = [[row, 0], [row, this.editor.indentationForBufferRow(row) * tabSize]];
+                // Otherwise create the indentation string.
+                const toInsert = `${" ".repeat(Math.max(nextIndentationLevel, 0))}`;
+                const range = [[row, 0], [row, this.editor.indentationForBufferRow(row) * tabSize]];
 
-            // Only set the new indent if it's different than what the editor chose.
-            const currentIndent = this.editor.getTextInBufferRange(range);
-            if (currentIndent !== toInsert) {
-                this.editor.getBuffer().setTextInRange(range, toInsert);
-            }
+                // Only set the new indent if it's different than what the editor chose.
+                const currentIndent = this.editor.getTextInBufferRange(range);
+                if (currentIndent !== toInsert) {
+                    this.editor.getBuffer().setTextInRange(range, toInsert);
+                }
+            });
         });
     }
 }

--- a/spec/python-indent-spec.js
+++ b/spec/python-indent-spec.js
@@ -680,6 +680,19 @@ describe("python-indent", () => {
         });
     });
 
+    /*
+    print("1")
+    print("2")
+    */
+    describe("when multiple cursors are used", () => it("indents at both cursors", () => {
+        editor.insertText("print('1',\n)\nprint('2',\n)");
+        editor.setCursorBufferPosition([1, 6]);
+        editor.addCursorAtBufferPosition([4, 4]);
+        pythonIndent.indent();
+        expect(buffer.lineForRow(1)).toBe(`${" ".repeat(6)})`);
+        expect(buffer.lineForRow(3)).toBe(`${" ".repeat(6)})`);
+    }));
+
     describe("when source is malformed", () => it("does not throw error or indent when code is malformed", () => {
         editor.insertText("class DoesBadlyFormedCodeBreak )\n");
         expect(() => pythonIndent.indent())

--- a/spec/test_file.py
+++ b/spec/test_file.py
@@ -77,6 +77,11 @@ class TheClass(object):
              param_c):
         a_list = ["1", "2", "3",
                   "4"]
+
+# Multi Cursor
+print("1"):
+print("2"):
+
 x = [
     0, 1, 2,
     3, 4, 5


### PR DESCRIPTION
The Atom API has a `getCursorBufferPositions` which provides an array of
buffer positions where cursors are at. This commit simply loops through
those rather using the single value provided by
`getCursorBufferPosition` (which only gives the last position). A test
was also added to lightly cover these scenarios.

Fixes #59.