### PR TITLE
Remove broken apm badge from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.4] - 2019-05-31
+### Changed
+- Remove broken apm badge.
+
 ## [1.2.3] - 2019-05-14
 ### Fixed
 - Fix regression that first occurred in 1.2.2 where a text buffer was trying to
@@ -189,7 +193,8 @@ in the line (perhaps a string).
 - Fluid indent in tuples, lists, and parameters.
 - Unindent to tab after fluid indented tuples, lists and parameters.
 
-[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.2.3...HEAD
+[Unreleased]: https://github.com/DSpeckhals/python-indent/compare/v1.2.4...HEAD
+[1.2.4]: https://github.com/DSpeckhals/python-indent/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/DSpeckhals/python-indent/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/DSpeckhals/python-indent/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/DSpeckhals/python-indent/compare/v1.2.0...v1.2.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # python-indent [![Build Status](https://travis-ci.com/DSpeckhals/python-indent.svg?branch=master)](https://travis-ci.com/DSpeckhals/python-indent)
 
-[![apm install python-indent](https://apm-badges.herokuapp.com/apm/python-indent.svg?theme=one-dark)](https://atom.io/packages/python-indent)
-
 _Atom with easy PEP8 indentation...No more space bar mashing!_
 
 ![example of python-indent](https://raw.githubusercontent.com/DSpeckhals/python-indent/master/resources/img/python-indent-demonstration.gif)


### PR DESCRIPTION
It appears that the Heroku app for it is no longer running, and the
app doesn't appear to be maintained either.